### PR TITLE
Fix callsign mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ $ python proph.py load-diffs <directory of diffs> <project number>
 _Requires Arcanist and access to the Phabricator database_
 
 **Before running this command you should have already ran `create-marker-groups` and `create-student-groups` so the
-differential revision policies can be effective**
+differential revision policies can be effective. `lockdown-repos` should also be run to get the correct callsign mappings.**
 
 Import all git diff files with `.diff` extension from the `<directory of diffs>` directory and perform the following actions for each file:
 

--- a/phabricator/diff.py
+++ b/phabricator/diff.py
@@ -19,7 +19,8 @@ VALUES (%s, %s, 35, %s, 0)"""
 
 diff_callsign_mapping_sql = """SELECT r.callsign, p.name
 FROM default_repository.repository r
-JOIN default_project.project p ON r.editPolicy = p.phid
+JOIN default_policy.policy pol ON r.editPolicy = pol.phid
+JOIN default_project.project p ON pol.rules LIKE CONCAT('%', p.phid, '%')
 """
 
 class Diff():


### PR DESCRIPTION
Updated the SQL for phabricator diffs, so that it finds the callsign mappings after the lockdown-repos command is run.